### PR TITLE
added period between subdomain and domain

### DIFF
--- a/account-management-util/src/main/java/org/duracloud/account/db/util/notification/Notifier.java
+++ b/account-management-util/src/main/java/org/duracloud/account/db/util/notification/Notifier.java
@@ -99,6 +99,7 @@ public class Notifier {
         sb.append(accountInfo.getAcctName());
         sb.append(" account at https://");
         sb.append(accountInfo.getSubdomain());
+        sb.append(".");
         sb.append(amaEndpoint.getDomain());
         sb.append(" with the following username: " + user.getUsername() + ".");
         sb.append("\n\n");


### PR DESCRIPTION
My last PR that parameterized the domain introduced a typo in the notification email sent to new users.