### PR TITLE
DURACLOUD-1142 Allow to configure the region for the S3 Storage provider

### DIFF
--- a/account-management-app/src/main/resources/root.properties
+++ b/account-management-app/src/main/resources/root.properties
@@ -46,6 +46,7 @@ globalproperties.cloudfrontkeyid=CloudFront Key Id
 globalproperties.cloudfrontkeypath=CloudFront Key Path
 
 storageprovider.storagelimit=Storage Limit (in TB)
+amazon.region=Amazon Region (default empty)
 bridge.snapshotuser=Snapshot User
 bridge.host=Bridge Host
 bridge.port=Bridge Port

--- a/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
@@ -67,10 +67,17 @@
 	                <form:label
 	                 cssErrorClass="error"
 	                 path="${param.storageProvider}.properties['AWS_REGION']"><spring:message code="amazon.region"/></form:label>
-	                <form:input
-	                 cssErrorClass="error"
-	                 path="${param.storageProvider}.properties['AWS_REGION']"
-	                 onclick="same(this.form)"/>
+                    <spring:eval expression="T(com.amazonaws.regions.RegionUtils).getRegions()" var="awsregions" />
+                    <form:select
+                     cssErrorClass="error"
+                     id="${param.storageProvider}.properties['AWS_REGION']"
+                     path="${param.storageProvider}.properties['AWS_REGION']"
+                     onclick="same(this.form)">
+                       <form:option value="" label="" />
+                       <c:forEach items="${awsregions}" var="region">
+                         <form:option value="${region.name}" label="${region.name}" />
+                       </c:forEach>
+                    </form:select>
 	                <form:errors
 	                 path="${param.storageProvider}.properties['AWS_REGION']"
 	                 cssClass="error"

--- a/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
@@ -62,6 +62,22 @@
                  element="div" />               
               </li>
 	            
+	            <c:if test="${param.storageProviderType eq 'AMAZON_S3'}">
+	              <li>
+	                <form:label
+	                 cssErrorClass="error"
+	                 path="${param.storageProvider}.properties['AWS_REGION']"><spring:message code="amazon.region"/></form:label>
+	                <form:input
+	                 cssErrorClass="error"
+	                 path="${param.storageProvider}.properties['AWS_REGION']"
+	                 onclick="same(this.form)"/>
+	                <form:errors
+	                 path="${param.storageProvider}.properties['AWS_REGION']"
+	                 cssClass="error"
+	                 element="div" />               
+	              </li>
+	            </c:if>
+	            
 	            <c:if test="${param.storageProviderType eq 'DPN' || param.storageProviderType eq 'CHRONOPOLIS'}">
 	              <li>
 	                <form:label


### PR DESCRIPTION
This change allows to store an option value for the S3 provider to define the AWS Region to use.
An empty string correspond to the current behavior (us-east-1).
Acceptable values are:
- eu-west-1
- eu-west-2
- ...

Currently a text input is used, it will be better to have a dropdown