### PR TITLE
DURACLOUD-1146 set an empty default for credentials

### DIFF
--- a/account-management-app/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/account-management-app/src/main/webapp/WEB-INF/applicationContext.xml
@@ -24,8 +24,8 @@
     <constructor-arg value="${mc.port}"/>
     <constructor-arg value="${mc.context}"/>
     <constructor-arg value="${mc.domain}"/>
-    <constructor-arg value="${notification.user}"/>
-    <constructor-arg value="${notification.pass}"/>
+    <constructor-arg value="${notification.user:}"/>
+    <constructor-arg value="${notification.pass:}"/>
     <constructor-arg value="${notification.from-address}"/>
     <constructor-arg value="${notification.admin-address}"/>
     <constructor-arg value="${db.host}"/>


### PR DESCRIPTION
to avoid initialize exception for missing properties making possible the use of IAM role

see also
https://jira.duraspace.org/browse/DURACLOUD-1146
https://github.com/duracloud/duracloud/pull/27