### PR TITLE
Adds support for switching on non-root write control over secondary s…

### DIFF
--- a/account-management-app/src/main/resources/root.properties
+++ b/account-management-app/src/main/resources/root.properties
@@ -46,6 +46,7 @@ globalproperties.cloudfrontkeyid=CloudFront Key Id
 globalproperties.cloudfrontkeypath=CloudFront Key Path
 
 storageprovider.storagelimit=Storage Limit (in TB)
+storageprovider.writablebynonrootuser=Writable by non-root users
 amazon.region=Amazon Region (default empty)
 bridge.snapshotuser=Snapshot User
 bridge.host=Bridge Host

--- a/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
@@ -61,8 +61,23 @@
                  cssClass="error"
                  element="div" />               
               </li>
-	            
-	            <c:if test="${param.storageProviderType eq 'AMAZON_S3' || param.storageProviderType eq 'AMAZON_GLACIER'}">
+
+							<c:if test="${param.storageProviderRole eq 'secondary'}">
+								<li>
+									<form:label
+										cssErrorClass="error"
+										path="${param.storageProvider}.properties['WRITABLE_BY_NON_ROOT']">
+										<spring:message code="storageprovider.writablebynonrootuser"/>
+									</form:label>
+									<form:checkbox
+										cssErrorClass="error"
+										path="${param.storageProvider}.properties['WRITABLE_BY_NON_ROOT']"
+										value="true"
+										onclick="same(this.form)"/>
+								</li>
+							</c:if>
+
+							<c:if test="${param.storageProviderType eq 'AMAZON_S3' || param.storageProviderType eq 'AMAZON_GLACIER'}">
 	              <li>
 	                <form:label
 	                 cssErrorClass="error"

--- a/account-management-app/src/main/webapp/WEB-INF/jspx/root/accounts/setup.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/root/accounts/setup.jspx
@@ -31,6 +31,7 @@
           <jsp:include page="/WEB-INF/jspx/includes/storage-provider-form.jspx">
             <jsp:param value="primaryStorageProviderSettings" name="storageProvider"/>
             <jsp:param value="Primary Storage Provider" name="storageProviderName"/>
+            <jsp:param value="primary" name="storageProviderRole"/>
             <jsp:param value="${setupAccountForm.primaryStorageProviderSettings.providerType}" name="storageProviderType"/>
           </jsp:include>
           
@@ -41,7 +42,8 @@
                varStatus="loop"
                items="${setupAccountForm.secondaryStorageProviderSettingsList}">
 		          <jsp:include page="/WEB-INF/jspx/includes/storage-provider-form.jspx">
-		            <jsp:param value="secondaryStorageProviderSettingsList[${loop.index}]" name="storageProvider"/>
+                <jsp:param value="secondary" name="storageProviderRole"/>
+                <jsp:param value="secondaryStorageProviderSettingsList[${loop.index}]" name="storageProvider"/>
 		            <jsp:param value="Secondary Storage Provider" name="storageProviderName"/>
 		            <jsp:param value="${setupAccountForm.secondaryStorageProviderSettingsList[loop.index].providerType}" name="storageProviderType"/>
 		          </jsp:include>

--- a/account-management-monitor/src/test/java/org/duracloud/account/monitor/duplication/DuplicationMonitorTest.java
+++ b/account-management-monitor/src/test/java/org/duracloud/account/monitor/duplication/DuplicationMonitorTest.java
@@ -68,9 +68,9 @@ public class DuplicationMonitorTest {
         String secondaryId = "secondary-id";
         Map<String, ContentStore> stores = new HashMap<>();
         stores.put(primaryId,
-                   new ContentStoreImpl(null, null, primaryId, null));
+                   new ContentStoreImpl(null, null, primaryId, true, null));
         stores.put(secondaryId,
-                   new ContentStoreImpl(null, null, secondaryId, null));
+                   new ContentStoreImpl(null, null, secondaryId, true,null));
 
         EasyMock.expect(storeManager.getContentStores()).andReturn(stores);
 

--- a/account-management-util/src/main/java/org/duracloud/account/db/util/RootAccountManagerService.java
+++ b/account-management-util/src/main/java/org/duracloud/account/db/util/RootAccountManagerService.java
@@ -86,8 +86,8 @@ public interface RootAccountManagerService {
      * @param id
      * @param username
      * @param password
-     * @param storageLimit
      * @parma properties
+     * @param storageLimit
      */
     @Secured({"role:ROLE_ROOT, scope:ANY"})
     public void setupStorageProvider(Long id, String username, String password, Map<String, String> properties,

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <duracloud.artifact.version>5.0.0</duracloud.artifact.version>
+    <duracloud.artifact.version>5.1.0-SNAPSHOT</duracloud.artifact.version>
     <aws.version>1.11.155</aws.version>
     <duracloud.db.version>5.0.0</duracloud.db.version>
     <org.springframework.version>4.2.5.RELEASE</org.springframework.version>


### PR DESCRIPTION
**Adds support for switching on non-root write control over secondary spaces.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1201

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Essentially this PR adds a new field to the storage provider configuration form.
The data is stored in the storage provider properties.  
# How should this be tested?
Login to the MC.  Navigate to an account with two providers configured. Notice the new checkbox for making the provider writable by non root users.  Check it and save. refresh the page. Verify that it is still checked.  Uncheck it and save. Refresh. Verify that it is unchecked. 

# Additional Notes:
There is a PR  in duracloud that this PR depends on.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
