### PR TITLE
Duracloud 1221:  Adds ability to set AWS region for Chronopolis storage providers.

### DIFF
--- a/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/includes/storage-provider-form.jspx
@@ -77,7 +77,7 @@
               </li>
               </c:if>
 
-							<c:if test="${param.storageProviderType eq 'AMAZON_S3' || param.storageProviderType eq 'AMAZON_GLACIER'}">
+							<c:if test="${param.storageProviderType eq 'AMAZON_S3' || param.storageProviderType eq 'AMAZON_GLACIER' || param.storageProviderType eq 'CHRONOPOLIS'}">
 	              <li>
 	                <form:label
 	                 cssErrorClass="error"


### PR DESCRIPTION
**Adds ability to set AWS region for Chronopolis storage providers.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1221

# What does this Pull Request do?
Adds a drop down for selecting the region in the storage provider configuration screen.
# How should this be tested?
1. Root console ->  account : configure providers
2. verify dropdown is present in chronopolis section.
3. try selecting a region for the chronopolis provider and saving the view.
# Interested parties
@bbranan 