### PR TITLE
DURACLOUD-1229: Replaces default maven deploy plugin with nexus staging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,20 @@
 
     <plugins>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.6</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>sonatype-releases</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <!-- Ensures all artifacts are staged together in the same repo -->
+          <stagingProfileId>4f035a66af3dde</stagingProfileId>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1229

# What does this Pull Request do?

Replaces the default maven deployment with the nexus staging plugin, which is optimized for use with Sonatype Nexus. The primary need is to ensure that deployments from Travis CI are included in a single deployment repo, which should be accomplished with the inclusion of the stagingProfileId.

The added plug-in is a direct copy of the same plug-in within the primary duracloud codebase, where it has been in use for some time; the only thing new is the stagingProfileId setting.

# How should this be tested?

It's really difficult to test this without performing a release, as that is what actives use of the plugin. The expectation is that this would be tested as part of the next release.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers

@dbernstein 
