### PR TITLE
Associate password label and input on login

### DIFF
--- a/account-management-app/src/main/webapp/WEB-INF/jspx/login.jspx
+++ b/account-management-app/src/main/webapp/WEB-INF/jspx/login.jspx
@@ -103,7 +103,7 @@
               autofocus="true"
               id="username" /></li>
 
-            <li><label>Password</label> <input
+            <li><label for="password">Password</label> <input
               name="password"
               type="password"
               id="password" /></li>


### PR DESCRIPTION
**JIRA Ticket**: None

## What does this Pull Request do?
Associates the password input and it's associated label on the login page, similar to what is currently done with the username field

## How should this be tested?

Issue was first noticed when testing for accessibility issues with the WAVE browser extension. To test the fix, this or another accessibility testing tool could be used.