### PR TITLE
Prevents double slashes from appearing in the generated ama urls foun…

### DIFF
--- a/account-management-common/src/main/java/org/duracloud/account/config/AmaEndpoint.java
+++ b/account-management-common/src/main/java/org/duracloud/account/config/AmaEndpoint.java
@@ -35,8 +35,11 @@ public class AmaEndpoint {
     }
 
     public String getUrl() {
-        String proto = getPort().equals("443") ? "https" : "http";
-        return proto + "://" + getHost() + ":" + getPort() + "/" + getCtxt();
+        final var port = getPort();
+        final var proto = port.equals("443") ? "https" : "http";
+        final var portInUrl = port.equals("443") || port.equals("80") ? ""  : ":" + port;
+        final var context = getCtxt();
+        return proto + "://" + getHost() + portInUrl + (context.startsWith("/") ? "" : "/") + context;
     }
 
 }

--- a/account-management-common/src/main/java/org/duracloud/account/config/AmaEndpoint.java
+++ b/account-management-common/src/main/java/org/duracloud/account/config/AmaEndpoint.java
@@ -39,7 +39,7 @@ public class AmaEndpoint {
         final var proto = port.equals("443") ? "https" : "http";
         final var portInUrl = port.equals("443") || port.equals("80") ? ""  : ":" + port;
         final var context = getCtxt();
-        return proto + "://" + getHost() + portInUrl + (context.startsWith("/") ? "" : "/") + context;
+        return proto + "://" + getHost() + portInUrl + context;
     }
 
 }

--- a/account-management-common/src/test/java/org/duracloud/account/config/AmaEndpointTest.java
+++ b/account-management-common/src/test/java/org/duracloud/account/config/AmaEndpointTest.java
@@ -1,0 +1,33 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.account.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * author dbernstein
+ */
+public class AmaEndpointTest {
+
+    @Test
+    public void testGetUrl() {
+        var endpoint = createConfig("");
+        assertEquals("http://localhost:8080", endpoint.getUrl());
+
+        endpoint = createConfig("/context");
+        assertEquals("http://localhost:8080/context", endpoint.getUrl());
+    }
+
+    private AmaEndpoint createConfig(final String context) {
+        return new AmaEndpoint(new McConfig("localhost", "8080", context, "mydomain",
+                "SES", null, null, null, "25",
+                null, null, null, null, null, null, null));
+    }
+}


### PR DESCRIPTION
…d in emails.  Also removes the port from the urls when it is 80 or 443.
![Screen Shot 2021-12-09 at 12 30 01 PM](https://user-images.githubusercontent.com/344939/145477313-98dfdf03-13fb-4690-8ee8-3f9fee5e2558.png)
.